### PR TITLE
Fix: production環境のMailer設定修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,16 +69,14 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = Settings.default_url_options.to_h
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.perform_deliveries = true
-  config.action_mailer.default charset: 'utf-8'
   config.action_mailer.smtp_settings = {
     enable_starttls_auto: true,
     address: 'smtp.gmail.com',
     port: 587,
-    domain: 'smtp.gmail.com',
-    user_nam: Rails.application.credentials.gmail[:address],
+    domain: 'gmail.com',
+    user_name: Rails.application.credentials.gmail[:address],
     password: Rails.application.credentials.gmail[:password],
-    authentication: 'login'
+    authentication: :login
   }
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
## 概要
production環境のMailer設定を修正
- タイポ
- 記述方法間違え