### PR TITLE
Delete: TwitterAPIの仕様変更に伴いTwitterログインをviewから削除#138

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -19,7 +19,6 @@
             <%= f.submit t('defaults.login'), class: "btn" %>
           </div>
         <% end %>
-        <%= render 'shared/twitter_login' %>
         <div class="flex justify-center items-center mt-3">
           <%= link_to t('user_sessions.new.to_sign_up'), sign_up_path, class: "link link-hover" %>
         </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -28,7 +28,6 @@
             <%= f.submit t('defaults.register'), class: "btn" %>
           </div>
         <% end %>
-        <%= render 'shared/twitter_login' %>
         <div class="flex justify-center items-center mt-3">
           <%= link_to t('users.new.to_login'), login_path, class: "link link-hover" %>
         </div>


### PR DESCRIPTION
## 概要
Twitterログインのボタンをログイン・新規登録画面から削除